### PR TITLE
refactor: Selection of frequency of alerts only in phase 2

### DIFF
--- a/src/app/interactions/componentInteractions/handleComponentInteraction.ts
+++ b/src/app/interactions/componentInteractions/handleComponentInteraction.ts
@@ -15,7 +15,7 @@ import {
 	handleCircleSelect,
 	handleCreateNewEntities,
 	handleFinalMessage,
-	handleFrequencyOfAlertsToSend,
+	// handleFrequencyOfAlertsToSend,
 	handleLinkCircles,
 	handleRequestApiKeys,
 } from './handlers';
@@ -36,7 +36,9 @@ export async function handleComponentInteraction({ ctx, discordService }: Props)
 	case NO_SEND_ALERTS_BUTTON.custom_id:
 		return handleFinalMessage(ctx);
 	case ALERTS_SELECT_CONFIRM_BUTTON.custom_id:
-		return handleFrequencyOfAlertsToSend(ctx);
+		// TODO Phase 2
+		// return handleFrequencyOfAlertsToSend(ctx);
+		return handleFinalMessage(ctx);
 	case ALERTS_SELECT_CANCEL_BUTTON.custom_id:
 		return handleFinalMessage(ctx);
 	case ALERTS_FREQUENCY_SELECT_CONFIRM_BUTTON.custom_id:


### PR DESCRIPTION
The alerts based on Circle activity will be the last question for Phase 1, like so

<img width="1713" alt="Screenshot 2023-02-01 at 3 43 17 pm" src="https://user-images.githubusercontent.com/78794805/216059481-ea345de7-2263-42ad-943c-36ca87c1fc25.png">
