### PR TITLE
fix: Specify yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     "engines": {
         "node": "16",
-        "yarn": "*"
+        "yarn": "1.22.19"
     },
     "engineStrict": true,
     "_moduleAliases": {


### PR DESCRIPTION
## Problem

Build https://dashboard.heroku.com/apps/coordinape-discord-bot/activity/builds/5c7a7f5f-cb84-4fad-89f2-93908e0d5036 failed with
```
-----> Installing dependencies
       Installing node modules (yarn.lock)
       Unknown Syntax Error: Invalid option name ("--production=false").
       
       $ yarn install [--json] [--immutable] [--immutable-cache] [--check-cache] [--inline-builds] [--mode #0]
-----> Build failed
```

## Solution

Pin yarn's version to one that has the "--production=false" flag which appears to be added by heroku itself