### PR TITLE
feat: Alerts management when a channel is linked to a circle

### DIFF
--- a/src/app/api/getDiscordRolesCirclesAlerts.ts
+++ b/src/app/api/getDiscordRolesCirclesAlerts.ts
@@ -8,5 +8,8 @@ export async function getDiscordRolesCirclesAlerts({ channelId }: {channelId: st
 		],
 	});
 
-	return discord_roles_circles[0];
+	return discord_roles_circles[0] as {
+		discord_channel_id: string;
+		alerts: Record<string, boolean>;
+	};
 }

--- a/src/app/api/updateDiscordRolesCirclesAlerts.ts
+++ b/src/app/api/updateDiscordRolesCirclesAlerts.ts
@@ -28,5 +28,11 @@ export async function updateDiscordRolesCirclesAlerts({ channelId, alerts }: Pro
 		throw new Error('Something is wrong, please contact coordinape');
 	}
 	
-	return { success: !!update_discord_roles_circles.returning[0], data: update_discord_roles_circles.returning[0] };
+	return { success: !!update_discord_roles_circles.returning[0], data: update_discord_roles_circles.returning[0] } as {
+		success: boolean;
+		data: {
+			alerts: Record<string, boolean>;
+			id: string;
+		}
+	};
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -22,6 +22,8 @@ import constants from './service/constants/constants';
 import { RewriteFrames } from '@sentry/integrations';
 import { assignRoleHandler, handleAlertsSelect, handleAlertsToSend, handleCircleSelect, handleConfirmAlertsToSend, handleCreateNewEntities, handleFinalMessage, handleLinkCircles, handleRequestApiKeys, unassignRoleHandler } from './interactions/componentInteractions/handlers';
 import { CustomId } from './interactions/customId';
+import { handleLinkedCircleAlertsCancel } from './interactions/componentInteractions/handlers/configuration/handleLinkedCircleAlertsCancel';
+import { handleLinkedCircleAlertsUpdate } from './interactions/componentInteractions/handlers/configuration/handleLinkedCircleAlertsUpdate';
 
 initializeSentryIO();
 const client: Client = initializeClient();
@@ -40,6 +42,8 @@ const handleableInteractions: {[key: string]: (ctx: ComponentContext) => Promise
 	[CustomId.LinkCircleButton]: handleRequestApiKeys,
 	[CustomId.Skip]: handleFinalMessage,
 	[CustomId.UnssignRoleUserSelect]: assignRoleHandler,
+	[CustomId.LinkedChannelAlertsCancelButton]: handleLinkedCircleAlertsCancel,
+	[CustomId.LinkedChannelAlertsUpdateButton]: handleLinkedCircleAlertsUpdate,
 };
 
 const creator: SlashCreatorWithDiscordJS = new SlashCreator({

--- a/src/app/interactions/componentInteractions/handlers/configuration/2_handleLinkCircles.ts
+++ b/src/app/interactions/componentInteractions/handlers/configuration/2_handleLinkCircles.ts
@@ -4,6 +4,8 @@ import { Circle, getCircles } from '@api/getCircles';
 import { getLinkedCircles } from '@api/getLinkedCircles';
 import { CustomId } from 'src/app/interactions/customId';
 import { disableAllComponents } from '../common';
+import { CIRCLE_SELECT_NEXT_BUTTON, CIRCLE_SELECT_SKIP_BUTTON } from './2.1_handleCircleSelect';
+import { HELP_BUTTON } from 'src/app/common';
 
 export const ALL_CIRCLES_LINKED_CONTINUE_BUTTON: ComponentButton = {
 	type: ComponentType.BUTTON,
@@ -57,7 +59,10 @@ export async function handleLinkCircles(ctx: ComponentContext): Promise<void> {
 
 	ctx.send({
 		content: `I see you have ${getLinkedCirclesText(unlinkedCircles)}.\n\nI'll need to create a new channel and role in this server to link these Circles following this schema:\n\n> Channel = \`#circle-name\`\n> Role = \`@Circle Name Member\`\n\nFor example, for your circle "${unlinkedCircles[0].name}" I will create the channel \`#${_.kebabCase(unlinkedCircles[0].name)}\` and the role \`@${unlinkedCircles[0].name} Member\`\n\nPlease select the Circles that you want me to manage from the **dropdown list** and click Next`,
-		components: [{ type: ComponentType.ACTION_ROW, components: [buildCircleSelect({ circles: unlinkedCircles })] }],
+		components: [
+			{ type: ComponentType.ACTION_ROW, components: [buildCircleSelect({ circles: unlinkedCircles })] },
+			{ type: ComponentType.ACTION_ROW, components: [ { ...CIRCLE_SELECT_NEXT_BUTTON, disabled: true }, CIRCLE_SELECT_SKIP_BUTTON, HELP_BUTTON ] },
+		],
 	});
 }
 

--- a/src/app/interactions/componentInteractions/handlers/configuration/3.3_handleConfirmAlertsToSend.ts
+++ b/src/app/interactions/componentInteractions/handlers/configuration/3.3_handleConfirmAlertsToSend.ts
@@ -1,6 +1,8 @@
 import { updateDiscordRolesCirclesAlerts } from '@api/updateDiscordRolesCirclesAlerts';
 import { ComponentActionRow, ComponentContext, ComponentSelectMenu } from 'slash-create';
+import { sleep } from 'src/app/utils/sleep';
 import { disableAllComponents } from '../common';
+import { ALERTS, getUniqueAlertKeys } from './3.2_handleAlertsToSend';
 import { handleFinalMessage } from './4_handleFinalMessage';
 
 /**
@@ -11,29 +13,52 @@ export async function handleConfirmAlertsToSend(ctx: ComponentContext) {
 	const actionRow = ctx.message.components[0] as ComponentActionRow;
 	const select = actionRow.components[0] as ComponentSelectMenu;
 		
-	const alerts = select.options?.filter(option => option.default) || [];
-		
 	await ctx.editParent({ components: disableAllComponents(ctx) });
+
+	if (!select.options) {
+		await ctx.send('No options selected');
+		return;
+	}
+
+	const alerts = select.options.reduce((acc, alert) => {
+		acc[alert.value] = !!alert.default;
+		return acc;
+	}, {} as Record<string, boolean>);
 
 	const { success, data } = await updateDiscordRolesCirclesAlerts({
 		channelId: ctx.channelID,
-		alerts: alerts.reduce((acc, { value }) => {
-			acc[value] = true;
-			return acc;
-		}, {} as Record<string, boolean>),
+		alerts,
 	});
 
-	if (!success) {
+	if (!success || !data.alerts) {
 		await ctx.send('Failed to update alerts to send');
 		return;
 	}
 
-	const storedAlerts = Object.keys(data?.alerts || {}).join(', ');
+	const uniqueAlertKeys = getUniqueAlertKeys(alerts);
+	
+	await ctx.send(getAlertsText(uniqueAlertKeys));
 
-	await ctx.send(`Your alerts (${storedAlerts}) have been successfully updated!`);
-
+	// Just to improve message flow
+	await sleep(3000);
+		
 	// TODO Phase 2
 	// return handleFrequencyOfAlertsToSend(ctx);
 
 	return handleFinalMessage(ctx);
+}
+
+function getAlertsText({ activeAlerts, inactiveAlerts }: ReturnType<typeof getUniqueAlertKeys>) {
+	let text = '';
+	if (Object.keys(activeAlerts).length === 0) {
+		text += 'You will no longer be receiving any alerts.';
+	} else {
+		text += `You will now receive ${activeAlerts.length === 1 ? '1 alert' : `${activeAlerts.length} alerts`}: ${activeAlerts.map((key) => (`\`${ALERTS[key]}\``)).join(', ')}`;
+	}
+
+	if (Object.keys(inactiveAlerts).length !== 0) {
+		text += `\nYou will NOT receive ${inactiveAlerts.length === 1 ? '1 alert' : `${inactiveAlerts.length} alerts`} alerts: ${inactiveAlerts.map((key) => (`\`${ALERTS[key]}\``)).join(', ')}`;
+	}
+
+	return text;
 }

--- a/src/app/interactions/componentInteractions/handlers/configuration/handleLinkedCircleAlertsCancel.ts
+++ b/src/app/interactions/componentInteractions/handlers/configuration/handleLinkedCircleAlertsCancel.ts
@@ -1,0 +1,6 @@
+import { ComponentContext } from 'slash-create';
+import { disableAllComponents } from '../common';
+
+export async function handleLinkedCircleAlertsCancel(ctx: ComponentContext): Promise<void> {
+	await ctx.editParent({ components: disableAllComponents(ctx) });
+}

--- a/src/app/interactions/componentInteractions/handlers/configuration/handleLinkedCircleAlertsUpdate.ts
+++ b/src/app/interactions/componentInteractions/handlers/configuration/handleLinkedCircleAlertsUpdate.ts
@@ -1,0 +1,40 @@
+import { getDiscordRolesCirclesAlerts } from '@api/getDiscordRolesCirclesAlerts';
+import { ComponentContext, ComponentSelectOption, ComponentType } from 'slash-create';
+import { disableAllComponents } from '../common';
+import { ALERTS_SELECT_CANCEL_BUTTON, ALERTS_SELECT_CONFIRM_BUTTON, ALERTS, buildAlertsSelect, isValidAlert, ALERT_OPTIONS } from './3.2_handleAlertsToSend';
+
+export async function handleLinkedCircleAlertsUpdate(ctx: ComponentContext): Promise<void> {
+	await ctx.editParent({ components: disableAllComponents(ctx) });
+
+	const { alerts } = await getDiscordRolesCirclesAlerts({ channelId: ctx.channelID });
+
+	const currentAlerts = Object.entries(alerts || {});
+
+	let options = [];
+
+	if (currentAlerts.length === 0) {
+		options = ALERT_OPTIONS;
+	} else {
+		options = currentAlerts.reduce((acc, [key, value]) => {
+			if (!isValidAlert(key)) {
+				return acc;
+			}
+	
+			const option = { label: ALERTS[key], value: key, default: !!value };
+	
+			acc.push(option);
+	
+			return acc;
+		}, [] as ComponentSelectOption[]);
+	}
+
+	const selectComponent = buildAlertsSelect({ options });
+	
+	await ctx.send({
+		content: 'What Alerts would you like me to send?',
+		components: [
+			{ type: ComponentType.ACTION_ROW, components: [selectComponent] },
+			{ type: ComponentType.ACTION_ROW, components: [ALERTS_SELECT_CONFIRM_BUTTON, ALERTS_SELECT_CANCEL_BUTTON] },
+		],
+	});
+}

--- a/src/app/interactions/customId.ts
+++ b/src/app/interactions/customId.ts
@@ -10,4 +10,7 @@ export enum CustomId {
     LinkCircleButton = 'LINK_CIRCLE_BUTTON',
     Skip = 'SKIP',
     UnssignRoleUserSelect = 'UNASSIGN_ROLE_USER_SELECT',
+    LinkedChannelAlertsButton = 'LINKED_CHANNEL_ALERTS_BUTTON',
+    LinkedChannelAlertsUpdateButton = 'LINKED_CHANNEL_ALERTS_UPDATE_BUTTON',
+    LinkedChannelAlertsCancelButton = 'LINKED_CHANNEL_ALERTS_CANCEL_BUTTON',
 }

--- a/src/app/service/ServiceSupport.ts
+++ b/src/app/service/ServiceSupport.ts
@@ -8,6 +8,7 @@ import Log from '../utils/Log';
 import { getLinkingComponents } from './components';
 import { getChangeRoleSelect } from './components/getChangeRoleSelect';
 import { getConfigureComponents } from './components/getConfigureComponents';
+import { getLinkedChannelComponents } from './components/getLinkedChannelComponents';
 import { DiscordService } from './DiscordService';
 import { CallbackComponent, CallbackComponentsWithActionRows } from './types';
 
@@ -34,6 +35,12 @@ export class ServiceSupport {
 			const assignComponents = await getChangeRoleSelect();
 			componentActionRows.push({ type: ComponentType.ACTION_ROW, components: assignComponents.map(({ component }) => component) });
 			callbackComponents.push(...assignComponents);
+			
+			const linkedChannelComponents = await getLinkedChannelComponents();
+			componentActionRows.push({ type: ComponentType.ACTION_ROW, components: linkedChannelComponents.map(({ component }) => component) });
+			callbackComponents.push(...linkedChannelComponents);
+
+			return { componentActionRows, callbackComponents };
 		}
 		
 		const configComponents = await getConfigureComponents();

--- a/src/app/service/components/getLinkedChannelComponents.ts
+++ b/src/app/service/components/getLinkedChannelComponents.ts
@@ -1,0 +1,71 @@
+import { getDiscordRolesCirclesAlerts } from '@api/getDiscordRolesCirclesAlerts';
+import { AnyComponentButton, ComponentType, ButtonStyle, ComponentContext, ComponentButton } from 'slash-create';
+import { ALERTS, getUniqueAlertKeys } from 'src/app/interactions/componentInteractions/handlers';
+import { disableAllComponents } from 'src/app/interactions/componentInteractions/handlers/common';
+import { CustomId } from 'src/app/interactions/customId';
+import { CallbackComponent } from '../types';
+
+export const LINKED_CHANNEL_ALERTS_UPDATE_BUTTON: ComponentButton = {
+	type: ComponentType.BUTTON,
+	style: ButtonStyle.PRIMARY,
+	label: 'Update',
+	custom_id: CustomId.LinkedChannelAlertsUpdateButton,
+};
+
+export const LINKED_CHANNEL_ALERTS_CANCEL_BUTTON: ComponentButton = {
+	type: ComponentType.BUTTON,
+	style: ButtonStyle.DESTRUCTIVE,
+	label: 'Cancel',
+	custom_id: CustomId.LinkedChannelAlertsCancelButton,
+};
+
+export async function getLinkedChannelComponents(): Promise<CallbackComponent[]> {
+	const UPDATE_ALERTS_BUTTON: AnyComponentButton = {
+		type: ComponentType.BUTTON,
+		style: ButtonStyle.SUCCESS,
+		label: 'ALERTS',
+		custom_id: CustomId.LinkedChannelAlertsButton,
+	};
+
+	const components = [UPDATE_ALERTS_BUTTON];
+
+	const CALLBACKS = {
+		[UPDATE_ALERTS_BUTTON.custom_id]: async (ctx: ComponentContext) => {
+			await ctx.editParent({ components: disableAllComponents(ctx) });
+
+			const { alerts } = await getDiscordRolesCirclesAlerts({ channelId: ctx.channelID });
+
+			if (!alerts || Object.keys(alerts).length === 0) {
+				await ctx.send({
+					content: ('You are not receiving any alerts.'),
+					components: [{ type: ComponentType.ACTION_ROW, components: [LINKED_CHANNEL_ALERTS_UPDATE_BUTTON, LINKED_CHANNEL_ALERTS_CANCEL_BUTTON] }],
+				});
+				return;
+			}
+
+			const uniqueAlertKeys = getUniqueAlertKeys(alerts);
+			
+			await ctx.send({
+				content: getAlertsText(uniqueAlertKeys),
+				components: [{ type: ComponentType.ACTION_ROW, components: [LINKED_CHANNEL_ALERTS_UPDATE_BUTTON, LINKED_CHANNEL_ALERTS_CANCEL_BUTTON] }],
+			});
+		},
+	};
+
+	return components.map(component => ({ component, callback: CALLBACKS[component.custom_id] }));
+}
+
+function getAlertsText({ activeAlerts, inactiveAlerts }: ReturnType<typeof getUniqueAlertKeys>) {
+	let text = '';
+	if (Object.keys(activeAlerts).length === 0) {
+		text += 'You are currently not receiving any alerts.';
+	} else {
+		text += `You are currently receiving ${activeAlerts.length === 1 ? '1 alert' : `${activeAlerts.length} alerts`}: ${activeAlerts.map((key) => (`\`${ALERTS[key]}\``)).join(', ')}`;
+	}
+
+	if (Object.keys(inactiveAlerts).length !== 0) {
+		text += `\nYou are NOT receiving ${inactiveAlerts.length === 1 ? '1 alert' : `${inactiveAlerts.length} alerts`} alerts: ${inactiveAlerts.map((key) => (`\`${ALERTS[key]}\``)).join(', ')}`;
+	}
+
+	return text;
+}


### PR DESCRIPTION
Alert management when the channel is linked to a circle

When the user run `/coordinape` from a channel that has a circle linked, it will show an "Alerts" button which will allow the user to update the alerts preferences. It's handling the fact that we might in the future add new alerts