### PR TITLE
fix: Defer handlers replies

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -59,6 +59,8 @@ creator.on('modalInteraction', (message) => Log.warn(`modalInteraction: ${ messa
 creator.on('commandInteraction', (message) => Log.warn(`commandInteraction: ${ message }`));
 creator.on('unknownInteraction', (message) => Log.warn(`unknownInteraction: ${ message }`));
 creator.on('componentInteraction', async (componentContext) => {
+	componentContext.defer();
+	
 	try {
 		if (componentContext.componentType === ComponentType.USER_SELECT) {
 			if (componentContext.customID === CustomId.AssignRoleUserSelect) {

--- a/src/app/interactions/componentInteractions/handlers/changeRole/assignRoleHandler.ts
+++ b/src/app/interactions/componentInteractions/handlers/changeRole/assignRoleHandler.ts
@@ -24,8 +24,6 @@ export const ASSIGN_ROLE_USER_SELECT_CANCEL_BUTTON: ComponentButton = {
 
 export async function assignRoleHandler(componentContext: ComponentContext) {
 	try {
-		componentContext.defer();
-
 		const [userId] = componentContext.data.data.values || [];
 
 		if (!userId) {

--- a/src/app/interactions/componentInteractions/handlers/changeRole/unassignRoleHandler.ts
+++ b/src/app/interactions/componentInteractions/handlers/changeRole/unassignRoleHandler.ts
@@ -21,8 +21,6 @@ export const UNASSIGN_ROLE_USER_SELECT_CANCEL_BUTTON: ComponentButton = {
 
 export async function unassignRoleHandler(componentContext: ComponentContext) {
 	try {
-		componentContext.defer();
-
 		const [userId] = componentContext.data.data.values || [];
 
 		if (!userId) {

--- a/src/app/interactions/componentInteractions/handlers/configuration/2_handleLinkCircles.ts
+++ b/src/app/interactions/componentInteractions/handlers/configuration/2_handleLinkCircles.ts
@@ -39,8 +39,7 @@ export const buildCircleSelect = ({ circles, options }: {circles?: Circle[]; opt
 export async function handleLinkCircles(ctx: ComponentContext): Promise<void> {
 	await ctx.editParent({ components: disableAllComponents(ctx) });
 
-	const circles = await getCircles({ userId: ctx.user.id });
-	const linkedCircles = await getLinkedCircles();
+	const [circles, linkedCircles] = await Promise.all([getCircles({ userId: ctx.user.id }), getLinkedCircles()]);
 
 	const unlinkedCircles = circles.reduce((prev, curr) => {
 		if (linkedCircles.includes(curr.id)) {
@@ -57,7 +56,7 @@ export async function handleLinkCircles(ctx: ComponentContext): Promise<void> {
 		return;
 	}
 
-	ctx.send({
+	await ctx.send({
 		content: `I see you have ${getLinkedCirclesText(unlinkedCircles)}.\n\nI'll need to create a new channel and role in this server to link these Circles following this schema:\n\n> Channel = \`#circle-name\`\n> Role = \`@Circle Name Member\`\n\nFor example, for your circle "${unlinkedCircles[0].name}" I will create the channel \`#${_.kebabCase(unlinkedCircles[0].name)}\` and the role \`@${unlinkedCircles[0].name} Member\`\n\nPlease select the Circles that you want me to manage from the **dropdown list** and click Next`,
 		components: [
 			{ type: ComponentType.ACTION_ROW, components: [buildCircleSelect({ circles: unlinkedCircles })] },


### PR DESCRIPTION
We only have 3 seconds to reply to discord interactions, it's not enough for the deployed bot so we need to defer the reply