### PR TITLE
refactor: Authorization UX

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -44,6 +44,10 @@ const handleableInteractions: {[key: string]: (ctx: ComponentContext) => Promise
 	[CustomId.UnssignRoleUserSelect]: assignRoleHandler,
 	[CustomId.LinkedChannelAlertsCancelButton]: handleLinkedCircleAlertsCancel,
 	[CustomId.LinkedChannelAlertsUpdateButton]: handleLinkedCircleAlertsUpdate,
+	[CustomId.AuthorizeLinkCircleButton]: async (ctx) => {
+		await ctx.defer();
+		return;
+	},
 };
 
 const creator: SlashCreatorWithDiscordJS = new SlashCreator({

--- a/src/app/commands/test.ts
+++ b/src/app/commands/test.ts
@@ -146,8 +146,6 @@ export default class Help extends SlashCommand {
 		};
 
 		try {
-			await ctx.defer();
-
 			switch (ctx.subcommands[0]) {
 			case 'user-select':
 				await ctx.send({

--- a/src/app/interactions/componentInteractions/handlers/configuration/2.2_handleRequestApiKeys.ts
+++ b/src/app/interactions/componentInteractions/handlers/configuration/2.2_handleRequestApiKeys.ts
@@ -1,6 +1,7 @@
 import { wsChain } from '@api/gqlClients';
 import { insertCircleApiTokens } from '@api/insertCircleApiTokens';
-import { ButtonStyle, ComponentButtonLink, ComponentContext, ComponentType } from 'slash-create';
+import { ButtonStyle, ComponentButton, ComponentContext, ComponentType } from 'slash-create';
+import { CustomId } from 'src/app/interactions/customId';
 import { DiscordService } from 'src/app/service/DiscordService';
 import { extractCircleId } from 'src/app/utils/extractCircleId';
 import { isMessage } from 'src/app/utils/isMessage';
@@ -32,15 +33,15 @@ export async function handleRequestApiKeys(ctx: ComponentContext) {
 		throw new Error('Something went wrong, please contact coordinape support');
 	}
 
-	const AUTHORIZE_LINK_CIRCLE_BUTTON: ComponentButtonLink = {
+	const AUTHORIZE_LINK_CIRCLE_BUTTON: ComponentButton = {
 		type: ComponentType.BUTTON,
-		label: 'Authorize',
-		style: ButtonStyle.LINK,
-		url: `https://coordinape-git-staging-coordinape.vercel.app/discord/link?id=${rowId}&circleId=${circleId}`,
+		label: 'Listen for Authorization',
+		style: ButtonStyle.PRIMARY,
+		custom_id: CustomId.AuthorizeLinkCircleButton,
 	};
 
 	const message = await ctx.send({
-		content: 'Click on the button below to authorize',
+		content: `In order for discord to detect your authorization please click the button below, then go to the following link https://coordinape-git-staging-coordinape.vercel.app/discord/link?id=${rowId}&circleId=${circleId}`,
 		components: [
 			{ type: ComponentType.ACTION_ROW, components: [AUTHORIZE_LINK_CIRCLE_BUTTON] },
 		],

--- a/src/app/interactions/customId.ts
+++ b/src/app/interactions/customId.ts
@@ -13,4 +13,5 @@ export enum CustomId {
     LinkedChannelAlertsButton = 'LINKED_CHANNEL_ALERTS_BUTTON',
     LinkedChannelAlertsUpdateButton = 'LINKED_CHANNEL_ALERTS_UPDATE_BUTTON',
     LinkedChannelAlertsCancelButton = 'LINKED_CHANNEL_ALERTS_CANCEL_BUTTON',
+    AuthorizeLinkCircleButton = 'AUTHORIZE_LINK_CIRCLE_BUTTON',
 }


### PR DESCRIPTION
Given

> The Ephemeral Messages FAQ and Developer Documentation on Interaction Responses show that only interaction responses currently support ephemeral messages.
> 
> There will not be any support for uninvoked ephemeral messages, according to Mason, a Discord engineer (message link, screenshot), as it would open quite a lot of abuse possibilities.
> 
> As AEnterprise said in the Discord Developers server: "Imagine bots being able to spam advertisements only visible to specific members, that are not stored [on Discord's servers] so very little to no proof for Trust & Safety to even look up".

and since the hosted bot will probably take more than 3 seconds to reply, we're unable to defer the message without an user interaction. Unfortunately for us, discord does not listen to button link interactions, so my attempt at addressing this issue is to have a "real" button that the user needs to click so that the bot can then create a deferred message.