### PR TITLE
fix: Attempt to link again the same circle

### DIFF
--- a/src/app/api/findDiscordEntitiesByCircleId.ts
+++ b/src/app/api/findDiscordEntitiesByCircleId.ts
@@ -1,0 +1,28 @@
+import { gqlBot } from './gqlClients';
+
+type Props = {
+	circleId: number;
+}
+
+type R = Promise<{ channelId: string | null; roleId: string| null; }>
+
+export async function findDiscordEntitiesByCircleId({ circleId }: Props): R {
+	const { discord_roles_circles } = await gqlBot('query')({
+		discord_roles_circles: [
+			{ where: { circle_id: { _eq: circleId } } },
+			{ discord_channel_id: true, discord_role_id: true },
+		],
+	});
+
+	if (discord_roles_circles.length === 0) {
+		return { channelId: null, roleId: null };
+	}
+
+	if (discord_roles_circles.length > 1) {
+		throw new Error('You have more than one roles circles, please contact coordinape');
+	}
+
+	const { discord_channel_id, discord_role_id } = discord_roles_circles[0];
+
+	return { channelId: discord_channel_id, roleId: discord_role_id };
+}

--- a/src/app/service/DiscordService.ts
+++ b/src/app/service/DiscordService.ts
@@ -69,6 +69,16 @@ export class DiscordService {
 		}
 	}
 
+	async findRole(id: string): Promise<Role | null> {
+		try {
+			const guild = await this.findGuild();
+			return guild.roles.fetch(id);
+		} catch (e) {
+			Log.error(e);
+			return null;
+		}
+	}
+
 	private async getContextTextChannels(): Promise<Collection<string, TextChannel>> {
 		const guild = await this.findGuild();
 


### PR DESCRIPTION
Handle when the user selects a circle to be linked, the channel and role is created but they are ignored and the user tries again to get another channel and role created for the same circle.