### PR TITLE
refactor: Config subcommand

### DIFF
--- a/src/app/interactions/handlers/configuration/handleAddUserCircle.ts
+++ b/src/app/interactions/handlers/configuration/handleAddUserCircle.ts
@@ -19,7 +19,7 @@ export async function handleAddUserCircle(ctx: ComponentContext): Promise<void> 
 
 		if (!profileId) {
 			await ctx.send({
-				content: `<@${userId}> hasn't linked their Discord Account to Coordinape yet, please tell them to run \`/coordinape\` and click "Link" to link their account. Then you can try again\n\nYou can also add them directly in coordinape [here](https://app.coordinape.com/profile/me)`,
+				content: `<@${userId}> hasn't linked their Discord Account to Coordinape yet, please tell them to run \`/coordinape config\` and click "Link" to link their account. Then you can try again\n\nYou can also add them directly in coordinape [here](https://app.coordinape.com/profile/me)`,
 				ephemeral: true,
 			});
 			return;

--- a/src/app/interactions/handlers/configuration/handleAddUserCircleCancel.ts
+++ b/src/app/interactions/handlers/configuration/handleAddUserCircleCancel.ts
@@ -8,7 +8,7 @@ export async function handleAddUserCircleCancel(ctx: ComponentContext): Promise<
 		await disableAllParentComponents(ctx);
 
 		await ctx.send({
-			content: 'No worries, if you want to add another user just run `/coordinape` again',
+			content: 'No worries, if you want to add another user just run `/coordinape config` again',
 			ephemeral: true,
 		});
 	} catch (error) {

--- a/src/app/interactions/handlers/configuration/handleConfigButton.ts
+++ b/src/app/interactions/handlers/configuration/handleConfigButton.ts
@@ -27,7 +27,7 @@ export async function handleConfigButton(ctx: ComponentContext): Promise<void> {
 		}
 		
 		await ctx.send({
-			content: 'Thanks for adding the Coordinape Bot to your server! My job is to make using Coordinape as simple as possible for your team.\n\nTo do that I\'ll need to ask you a few questions first.\n\nIf you have any questions just click the help button below. If anything goes wrong in this process, you can always start this prompt over again by using the `/Coordinape` Command and clicking the Configure button',
+			content: 'Thanks for adding the Coordinape Bot to your server! My job is to make using Coordinape as simple as possible for your team.\n\nTo do that I\'ll need to ask you a few questions first.\n\nIf you have any questions just click the help button below. If anything goes wrong in this process, you can always start this prompt over again by using the `/coordinape config` Command and clicking the Configure button',
 			components: [{ type: ComponentType.ACTION_ROW, components: [CONFIG_NEXT_BUTTON, HELP_BUTTON] }],
 			ephemeral: true,
 		});

--- a/src/app/interactions/handlers/configuration/handleFinalMessage.ts
+++ b/src/app/interactions/handlers/configuration/handleFinalMessage.ts
@@ -12,7 +12,7 @@ export async function handleFinalMessage(ctx: ComponentContext) {
 		await disableAllParentComponents(ctx);
 	
 		await ctx.send({
-			content: 'That\'s all I need to get started for you! I\'ll be watching your Circles and doing my best to keep your team up to speed with what\'s going on!\n\nThe next step is to have your team use the /Coordinape Command and to click the Link button to join their Coordinape Account to Discord, so we can assign them the correct roles and alert them when changes need to be made!\n\nIf you want to change any of these settings just use the /Coordinape command and click the configure button',
+			content: 'That\'s all I need to get started for you! I\'ll be watching your Circles and doing my best to keep your team up to speed with what\'s going on!\n\nThe next step is to have your team use the `/coordinape config` Command and to click the Link button to join their Coordinape Account to Discord, so we can assign them the correct roles and alert them when changes need to be made!\n\nIf you want to change any of these settings just use the `/coordinape config` command and click the configure button',
 			ephemeral: true,
 		});
 	} catch (error) {

--- a/src/app/interactions/handlers/configuration/handleRemoveUserCircle.ts
+++ b/src/app/interactions/handlers/configuration/handleRemoveUserCircle.ts
@@ -19,7 +19,7 @@ export async function handleRemoveUserCircle(ctx: ComponentContext): Promise<voi
 
 		if (!profileId) {
 			await ctx.send({
-				content: `<@${userId}> hasn't linked their Discord Account to Coordinape yet, please tell them to run \`/coordinape\` and click "Link" to link their account. Then you can try again\n\nYou can also add them directly in coordinape [here](https://app.coordinape.com/profile/me)`,
+				content: `<@${userId}> hasn't linked their Discord Account to Coordinape yet, please tell them to run \`/coordinape config\` and click "Link" to link their account. Then you can try again\n\nYou can also add them directly in coordinape [here](https://app.coordinape.com/profile/me)`,
 				ephemeral: true,
 			});
 			return;

--- a/src/app/interactions/handlers/configuration/handleRemoveUserCircleCancel.ts
+++ b/src/app/interactions/handlers/configuration/handleRemoveUserCircleCancel.ts
@@ -8,7 +8,7 @@ export async function handleRemoveUserCircleCancel(ctx: ComponentContext): Promi
 		await disableAllParentComponents(ctx);
 
 		await ctx.send({
-			content: 'No worries, if you want to remove another user just run `/coordinape` again',
+			content: 'No worries, if you want to remove another user just run `/coordinape config` again',
 			ephemeral: true,
 		});
 	} catch (error) {

--- a/src/app/interactions/handlers/configuration/handleUnlinkButton.ts
+++ b/src/app/interactions/handlers/configuration/handleUnlinkButton.ts
@@ -17,7 +17,7 @@ export async function handleUnlinkButton(ctx: ComponentContext): Promise<void> {
 					
 		if (delete_discord_users && delete_discord_users.affected_rows === 1) {
 			await ctx.send({
-				content: 'I\'ve removed the link between Coordinape and Discord. I\'ll no longer be able to specifically notify you for any Coordinape events. You can still use the /coordinape Command in Discord severs where I\'m enabled!',
+				content: 'I\'ve removed the link between Coordinape and Discord. I\'ll no longer be able to specifically notify you for any Coordinape events. You can still use the `/coordinape config` Command in Discord severs where I\'m enabled!',
 				ephemeral: true,
 			});
 			return;


### PR DESCRIPTION
The `/coordinape` command now has subcommands, so refactored the message to reflect that.

The subcommand for the original command is `/coordinape config`