### PR TITLE
refactor: Remove unnecessary header

### DIFF
--- a/src/app/api/gqlClients.ts
+++ b/src/app/api/gqlClients.ts
@@ -8,7 +8,6 @@ export const gqlApiKey = (apiKey: string, headers?: {[key: string]: string}) => 
 	headers: {
 		'Authorization': `Bearer ${apiKey}`,
 		'content-type': 'application/json',
-		'x-hasura-role': 'api-user',
 		...headers,
 	},
 });


### PR DESCRIPTION
We don't need to explicitly set `api-user`, the authentication webhook will set that automatically if the request has an api prefixed token.